### PR TITLE
UI side lockout now only renders true preview + no toolbar available …

### DIFF
--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -611,6 +611,7 @@ const RoomPage: React.FC = () => {
                     </div>
 
                     <div data-color-mode="light" style={{flex: 1}}>
+                        {activeEditor === myUsername?(
                         <MDEditor
                             value={markdownText}
                             onChange={(value: string | undefined) => {
@@ -621,11 +622,13 @@ const RoomPage: React.FC = () => {
                                 }
                             }}
                             height={600}
-                            preview={activeEditor === myUsername ? "live" : "preview"}
                             textareaProps={{
                                 placeholder: "# Shared notes\n\nHere you can collaboratively edit notes..."
                             }}
-                        />
+                        />) : (
+                            <MDEditor hideToolbar={true} value = {markdownText} preview={"preview"} height={600}/>
+                            )
+                        }
                     </div>
                 </div>
 


### PR DESCRIPTION
- Different Editors rendered based on editor status
- When editor: switch views + toolbar
- When not editor: only render preview, disables toolbar, no way to change text